### PR TITLE
fix terminal year cohort as paper fish

### DIFF
--- a/WHAM/demo_projected_cohort_contributions.R
+++ b/WHAM/demo_projected_cohort_contributions.R
@@ -55,7 +55,7 @@ proj_cbaa <-
          Age = as.numeric(Age),
          Cohort = as.character(Year - Age),
          Cohort = ifelse(Age == mod$env$data$n_ages, "Plus group", Cohort),
-         Cohort = ifelse(Cohort %in% as.character(setdiff(proj$years_full, proj$years)), 
+         Cohort = ifelse(Cohort %in% as.character(setdiff(proj$years_full, proj$years[1:(length(proj$years)-1)])), 
                          "Projected recruits",
                          Cohort),
          Cohort = forcats::fct_relevel(Cohort, "Plus group")) %>%


### PR DESCRIPTION
The terminal year cohort (age 1 in the terminal year plus one) has now been added to the group of "Projected recruits" (aka paper fish). Thanks to Paul Nitschke for catching this issue.
